### PR TITLE
Todo作成者情報と最終更新日表示機能の実装

### DIFF
--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -15,6 +15,15 @@ if ((global as any).prisma) {
 export async function GET() {
   try {
     const todos = await prisma.todo.findMany({
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
       orderBy: {
         createdAt: 'desc',
       },
@@ -29,7 +38,7 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { title, description } = body;
+    const { title, description, createdById } = body;
 
     if (!title) {
       return NextResponse.json(
@@ -42,6 +51,16 @@ export async function POST(request: Request) {
       data: {
         title,
         description,
+        createdById,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
       },
     });
 

--- a/app/components/TodoForm.tsx
+++ b/app/components/TodoForm.tsx
@@ -20,12 +20,24 @@ export default function TodoForm({ onTodoCreated, onTodoDeleted, todoId }: TodoF
     setIsLoading(true);
 
     try {
+      // 現在のユーザー情報を取得
+      const userStr = localStorage.getItem('user');
+      let createdById = null;
+      if (userStr) {
+        try {
+          const user = JSON.parse(userStr);
+          createdById = user.id;
+        } catch (error) {
+          console.error('ユーザー情報の解析エラー:', error);
+        }
+      }
+
       const response = await fetch('/api/todos', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ title, description }),
+        body: JSON.stringify({ title, description, createdById }),
       });
 
       if (!response.ok) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,9 +136,13 @@ export default function Home() {
                     {todo.description && (
                       <p className="text-gray-600 mt-2">{todo.description}</p>
                     )}
-                    <p className="text-sm text-gray-500 mt-2">
-                      作成日: {new Date(todo.createdAt).toLocaleString()}
-                    </p>
+                    <div className="text-sm text-gray-500 mt-2">
+                      <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
+                      <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
+                      {todo.createdBy && (
+                        <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
+                      )}
+                    </div>
                   </div>
                   <button
                     onClick={() => handleDelete(todo.id)}

--- a/app/types/todo.ts
+++ b/app/types/todo.ts
@@ -5,4 +5,10 @@ export interface Todo {
   completed: boolean;
   createdAt: string;
   updatedAt: string;
+  createdById?: number | null;
+  createdBy?: {
+    id: number;
+    name: string | null;
+    email: string;
+  } | null;
 } 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,13 +8,14 @@ datasource db {
 }
 
 model User {
-  id        Int      @id @default(autoincrement())
-  email     String   @unique
-  name      String?
-  password  String
-  todos     Todo[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  id          Int      @id @default(autoincrement())
+  email       String   @unique
+  name        String?
+  password    String
+  todos       Todo[]
+  createdTodos Todo[]   @relation("TodoCreatedBy")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model Todo {
@@ -23,7 +24,9 @@ model Todo {
   description String?
   completed   Boolean  @default(false)
   userId      Int?
+  createdById Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   user        User?    @relation(fields: [userId], references: [id])
+  createdBy   User?    @relation("TodoCreatedBy", fields: [createdById], references: [id])
 }


### PR DESCRIPTION
## Summary
- Todoに作成者情報を追加し、一覧で最終更新日も表示する機能を実装
- データベーススキーマを更新して作成者IDフィールドを追加
- MCP Playwrightでのテスト検証済み

## 主な変更点
- ✅ データベーススキーマにcreatedByIdフィールドを追加
- ✅ Todo API (GET) で作成者情報を含めて返却
- ✅ Todo API (POST) で作成者IDを設定
- ✅ Todo一覧画面で作成者名、作成日、更新日を表示
- ✅ TypeScript型定義を更新（Todo interface）

## 機能詳細
### データベース変更
- User modelに createdTodos relation を追加
- Todo modelに createdById フィールドと createdBy relation を追加

### API変更
- GET /api/todos: 作成者情報を include して返却
- POST /api/todos: createdById パラメータを受け取り設定

### UI改善
- Todo一覧で以下の情報を表示:
  - 作成日（既存）
  - 更新日（新規）
  - 作成者名（新規）

## Test plan
- [x] Docker環境でのアプリケーション起動確認
- [x] adminユーザーでTodo作成テスト
- [x] testユーザーでTodo作成テスト
- [x] 作成者情報が正しく表示されることを確認
- [x] 更新日が表示されることを確認
- [x] MCP Playwrightを使用したE2Eテスト完了

🤖 Generated with [Claude Code](https://claude.ai/code)