### PR TITLE
Todo担当者割り振りと編集機能の実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,9 @@
       "mcp__playwright__browser_snapshot",
       "mcp__playwright__browser_type",
       "mcp__playwright__browser_click",
-      "mcp__playwright__browser_close"
+      "mcp__playwright__browser_close",
+      "Bash(git checkout:*)",
+      "mcp__playwright__browser_handle_dialog"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,9 @@
       "mcp__playwright__browser_click",
       "mcp__playwright__browser_close",
       "Bash(git checkout:*)",
-      "mcp__playwright__browser_handle_dialog"
+      "mcp__playwright__browser_handle_dialog",
+      "Bash(curl:*)",
+      "mcp__playwright__browser_select_option"
     ],
     "deny": []
   }

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -24,6 +24,22 @@ export async function GET(
 
     const todo = await prisma.todo.findUnique({
       where: { id },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        assignedTo: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
     });
 
     if (!todo) {
@@ -54,7 +70,7 @@ export async function PUT(
     }
 
     const body = await request.json();
-    const { title, description, completed } = body;
+    const { title, description, completed, assignedToId } = body;
 
     if (!title) {
       return NextResponse.json(
@@ -69,6 +85,23 @@ export async function PUT(
         title,
         description,
         completed,
+        assignedToId,
+      },
+      include: {
+        createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        assignedTo: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
       },
     });
 

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -23,6 +23,13 @@ export async function GET() {
             email: true,
           },
         },
+        assignedTo: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
       },
       orderBy: {
         createdAt: 'desc',
@@ -38,7 +45,7 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const body = await request.json();
-    const { title, description, createdById } = body;
+    const { title, description, createdById, assignedToId } = body;
 
     if (!title) {
       return NextResponse.json(
@@ -52,9 +59,17 @@ export async function POST(request: Request) {
         title,
         description,
         createdById,
+        assignedToId,
       },
       include: {
         createdBy: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        assignedTo: {
           select: {
             id: true,
             name: true,

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+
+let prisma: PrismaClient;
+if ((global as any).prisma) {
+  prisma = (global as any).prisma;
+} else {
+  prisma = new PrismaClient();
+  if (process.env.NODE_ENV === 'test') {
+    (global as any).prisma = prisma;
+  }
+}
+
+// GET /api/users - すべてのユーザーを取得（担当者選択用）
+export async function GET() {
+  try {
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        name: true,
+        email: true,
+      },
+      orderBy: {
+        name: 'asc',
+      },
+    });
+    return NextResponse.json(users);
+  } catch (error) {
+    return NextResponse.json({ error: 'ユーザーの取得に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/components/TodoForm.tsx
+++ b/app/components/TodoForm.tsx
@@ -1,55 +1,124 @@
 'use client';
 
 import React from 'react';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+
+interface User {
+  id: number;
+  name: string | null;
+  email: string;
+}
 
 interface TodoFormProps {
   onTodoCreated: () => void;
   onTodoDeleted?: (id: string) => void;
   todoId?: string;
+  initialData?: {
+    title: string;
+    description: string;
+    assignedToId?: number | null;
+  };
+  isEditMode?: boolean;
+  onTodoUpdated?: () => void;
 }
 
-export default function TodoForm({ onTodoCreated, onTodoDeleted, todoId }: TodoFormProps) {
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
+export default function TodoForm({ 
+  onTodoCreated, 
+  onTodoDeleted, 
+  todoId, 
+  initialData, 
+  isEditMode = false, 
+  onTodoUpdated 
+}: TodoFormProps) {
+  const [title, setTitle] = useState(initialData?.title || '');
+  const [description, setDescription] = useState(initialData?.description || '');
+  const [assignedToId, setAssignedToId] = useState<number | null>(initialData?.assignedToId || null);
+  const [users, setUsers] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    // ユーザー一覧を取得
+    const fetchUsers = async () => {
+      try {
+        const response = await fetch('/api/users');
+        if (response.ok) {
+          const userData = await response.json();
+          setUsers(userData);
+        }
+      } catch (error) {
+        console.error('ユーザー一覧の取得エラー:', error);
+      }
+    };
+
+    fetchUsers();
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
 
     try {
-      // 現在のユーザー情報を取得
-      const userStr = localStorage.getItem('user');
-      let createdById = null;
-      if (userStr) {
-        try {
-          const user = JSON.parse(userStr);
-          createdById = user.id;
-        } catch (error) {
-          console.error('ユーザー情報の解析エラー:', error);
+      if (isEditMode && todoId) {
+        // 編集モード
+        const response = await fetch(`/api/todos/${todoId}`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ 
+            title, 
+            description, 
+            assignedToId: assignedToId || null,
+            completed: false 
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('Todoの更新に失敗しました');
         }
+
+        if (onTodoUpdated) {
+          onTodoUpdated();
+        }
+      } else {
+        // 作成モード
+        const userStr = localStorage.getItem('user');
+        let createdById = null;
+        if (userStr) {
+          try {
+            const user = JSON.parse(userStr);
+            createdById = user.id;
+          } catch (error) {
+            console.error('ユーザー情報の解析エラー:', error);
+          }
+        }
+
+        const response = await fetch('/api/todos', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ 
+            title, 
+            description, 
+            createdById,
+            assignedToId: assignedToId || null
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error('Todoの作成に失敗しました');
+        }
+
+        setTitle('');
+        setDescription('');
+        setAssignedToId(null);
+        onTodoCreated();
       }
-
-      const response = await fetch('/api/todos', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ title, description, createdById }),
-      });
-
-      if (!response.ok) {
-        throw new Error('Todoの作成に失敗しました');
-      }
-
-      setTitle('');
-      setDescription('');
-      onTodoCreated();
     } catch (error) {
       console.error('Error:', error);
-      alert('Todoの作成に失敗しました');
+      alert(isEditMode ? 'Todoの更新に失敗しました' : 'Todoの作成に失敗しました');
     } finally {
       setIsLoading(false);
     }
@@ -106,13 +175,31 @@ export default function TodoForm({ onTodoCreated, onTodoDeleted, todoId }: TodoF
           className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
         />
       </div>
+      <div>
+        <label htmlFor="assignedTo" className="block text-sm font-medium text-gray-700">
+          担当者
+        </label>
+        <select
+          id="assignedTo"
+          value={assignedToId || ''}
+          onChange={(e) => setAssignedToId(e.target.value ? parseInt(e.target.value) : null)}
+          className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+        >
+          <option value="">担当者なし</option>
+          {users.map((user) => (
+            <option key={user.id} value={user.id}>
+              {user.name || user.email}
+            </option>
+          ))}
+        </select>
+      </div>
       <div className="flex space-x-4">
         <button
           type="submit"
           disabled={isLoading}
           className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
         >
-          {isLoading ? '作成中...' : 'Todoを作成'}
+{isLoading ? (isEditMode ? '更新中...' : '作成中...') : (isEditMode ? 'Todoを更新' : 'Todoを作成')}
         </button>
         {todoId && (
           <button

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -142,6 +142,9 @@ export default function Home() {
                       {todo.createdBy && (
                         <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
                       )}
+                      {todo.assignedTo && (
+                        <p>担当者: {todo.assignedTo.name || todo.assignedTo.email}</p>
+                      )}
                     </div>
                   </div>
                   <button

--- a/app/todos/[id]/page.tsx
+++ b/app/todos/[id]/page.tsx
@@ -4,10 +4,12 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Todo } from '../../types/todo';
+import TodoForm from '../../components/TodoForm';
 
 export default function TodoDetail({ params }: { params: { id: string } }) {
   const [todo, setTodo] = useState<Todo | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isEditMode, setIsEditMode] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -51,6 +53,24 @@ export default function TodoDetail({ params }: { params: { id: string } }) {
     }
   };
 
+  const handleTodoUpdated = () => {
+    // Todo更新後は詳細画面を再読み込み
+    const fetchTodo = async () => {
+      try {
+        const response = await fetch(`/api/todos/${params.id}`);
+        if (response.ok) {
+          const data = await response.json();
+          setTodo(data);
+        }
+      } catch (error) {
+        console.error('Error:', error);
+      }
+    };
+    
+    fetchTodo();
+    setIsEditMode(false);
+  };
+
   if (isLoading) {
     return (
       <main className="container mx-auto px-4 py-8">
@@ -77,44 +97,95 @@ export default function TodoDetail({ params }: { params: { id: string } }) {
         </div>
 
         <div className="bg-white shadow rounded-lg p-6">
-          <h1 className="text-3xl font-bold mb-4">{todo.title}</h1>
-          
-          {todo.description && (
-            <div className="mb-6">
-              <h2 className="text-xl font-semibold mb-2">説明</h2>
-              <p className="text-gray-700">{todo.description}</p>
+          {isEditMode ? (
+            <div>
+              <h1 className="text-3xl font-bold mb-6">Todoを編集</h1>
+              <TodoForm
+                initialData={{
+                  title: todo.title,
+                  description: todo.description || '',
+                  assignedToId: todo.assignedToId,
+                }}
+                isEditMode={true}
+                todoId={params.id}
+                onTodoCreated={() => {}}
+                onTodoUpdated={handleTodoUpdated}
+              />
+              <div className="mt-4">
+                <button
+                  onClick={() => setIsEditMode(false)}
+                  className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                  キャンセル
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <h1 className="text-3xl font-bold mb-4">{todo.title}</h1>
+              
+              {todo.description && (
+                <div className="mb-6">
+                  <h2 className="text-xl font-semibold mb-2">説明</h2>
+                  <p className="text-gray-700">{todo.description}</p>
+                </div>
+              )}
+
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold mb-2">ステータス</h2>
+                <p className="text-gray-700">
+                  {todo.completed ? '完了' : '未完了'}
+                </p>
+              </div>
+
+              {todo.createdBy && (
+                <div className="mb-6">
+                  <h2 className="text-xl font-semibold mb-2">作成者</h2>
+                  <p className="text-gray-700">
+                    {todo.createdBy.name || todo.createdBy.email}
+                  </p>
+                </div>
+              )}
+
+              {todo.assignedTo && (
+                <div className="mb-6">
+                  <h2 className="text-xl font-semibold mb-2">担当者</h2>
+                  <p className="text-gray-700">
+                    {todo.assignedTo.name || todo.assignedTo.email}
+                  </p>
+                </div>
+              )}
+
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold mb-2">作成日時</h2>
+                <p className="text-gray-700">
+                  {new Date(todo.createdAt).toLocaleString()}
+                </p>
+              </div>
+
+              <div className="mb-6">
+                <h2 className="text-xl font-semibold mb-2">更新日時</h2>
+                <p className="text-gray-700">
+                  {new Date(todo.updatedAt).toLocaleString()}
+                </p>
+              </div>
+
+              <div className="flex justify-end space-x-4">
+                <button
+                  onClick={() => setIsEditMode(true)}
+                  className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                >
+                  編集
+                </button>
+                <button
+                  onClick={handleDelete}
+                  className="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                >
+                  削除
+                </button>
+              </div>
             </div>
           )}
-
-          <div className="mb-6">
-            <h2 className="text-xl font-semibold mb-2">ステータス</h2>
-            <p className="text-gray-700">
-              {todo.completed ? '完了' : '未完了'}
-            </p>
-          </div>
-
-          <div className="mb-6">
-            <h2 className="text-xl font-semibold mb-2">作成日時</h2>
-            <p className="text-gray-700">
-              {new Date(todo.createdAt).toLocaleString()}
-            </p>
-          </div>
-
-          <div className="mb-6">
-            <h2 className="text-xl font-semibold mb-2">更新日時</h2>
-            <p className="text-gray-700">
-              {new Date(todo.updatedAt).toLocaleString()}
-            </p>
-          </div>
-
-          <div className="flex justify-end">
-            <button
-              onClick={handleDelete}
-              className="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-            >
-              削除
-            </button>
-          </div>
         </div>
       </div>
     </main>

--- a/app/types/todo.ts
+++ b/app/types/todo.ts
@@ -6,7 +6,13 @@ export interface Todo {
   createdAt: string;
   updatedAt: string;
   createdById?: number | null;
+  assignedToId?: number | null;
   createdBy?: {
+    id: number;
+    name: string | null;
+    email: string;
+  } | null;
+  assignedTo?: {
     id: number;
     name: string | null;
     email: string;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   password    String
   todos       Todo[]
   createdTodos Todo[]   @relation("TodoCreatedBy")
+  assignedTodos Todo[]  @relation("TodoAssignedTo")
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 }
@@ -25,8 +26,10 @@ model Todo {
   completed   Boolean  @default(false)
   userId      Int?
   createdById Int?
+  assignedToId Int?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   user        User?    @relation(fields: [userId], references: [id])
   createdBy   User?    @relation("TodoCreatedBy", fields: [createdById], references: [id])
+  assignedTo  User?    @relation("TodoAssignedTo", fields: [assignedToId], references: [id])
 }


### PR DESCRIPTION
## Summary
- Todoに担当者を割り振る機能を追加
- Todo詳細画面で編集ボタンを追加し、編集機能を実装
- Todo一覧で担当者情報も表示するよう改善

## 主な変更点
### データベース変更
- ✅ Todo modelにassignedToIdフィールドを追加
- ✅ User modelにassignedTodos relationを追加
- ✅ データベース完全リセットで新スキーマ適用

### API変更
- ✅ GET /api/todos: 担当者情報をincludeして返却
- ✅ GET /api/todos/[id]: 担当者情報をincludeして返却
- ✅ POST /api/todos: assignedToIdパラメータを受け取り設定
- ✅ PUT /api/todos/[id]: assignedToIdパラメータでの更新対応
- ✅ GET /api/users: ユーザー一覧取得API新規追加

### UI改善
- ✅ TodoFormに担当者選択ドロップダウンを追加
- ✅ Todo詳細画面に編集ボタンを追加
- ✅ 詳細画面で編集モードと表示モードを切り替え
- ✅ Todo一覧で担当者名を表示
- ✅ 詳細画面で作成者・担当者・日時情報を表示

### 機能詳細
#### 担当者機能
- Todo作成時に担当者を選択可能（担当者なしも選択可能）
- Todo編集時に担当者を変更可能
- ドロップダウンで全ユーザーから選択

#### 編集機能
- Todo詳細画面に「編集」ボタンを追加
- 編集モードではTodoFormを再利用してタイトル、説明、担当者を編集可能
- 編集完了後は自動で詳細画面を再読み込み

## TypeScript対応
- ✅ Todo interfaceにassignedToId, assignedToフィールドを追加
- ✅ TodoFormPropsに編集機能用のプロパティを追加

## Test plan
- [x] Docker環境でのアプリケーション起動
- [x] adminユーザーでログイン
- [x] Todo作成時の担当者選択機能
- [x] Todo一覧での担当者表示確認  
- [x] Todo詳細画面での編集ボタン表示
- [x] Todo編集機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)