### PR TITLE
Todo一覧画面のリファクタリング: 新規作成分離と優先表示機能

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,8 @@
       "Bash(git checkout:*)",
       "mcp__playwright__browser_handle_dialog",
       "Bash(curl:*)",
-      "mcp__playwright__browser_select_option"
+      "mcp__playwright__browser_select_option",
+      "Bash(mkdir:*)"
     ],
     "deny": []
   }

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -12,8 +12,11 @@ if ((global as any).prisma) {
 }
 
 // GET /api/todos - すべてのTodoを取得
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const currentUserId = searchParams.get('currentUserId');
+    
     const todos = await prisma.todo.findMany({
       include: {
         createdBy: {
@@ -35,6 +38,16 @@ export async function GET() {
         createdAt: 'desc',
       },
     });
+
+    // currentUserIdが指定されている場合、そのユーザーが担当のタスクを上位に移動
+    if (currentUserId) {
+      const userIdNum = parseInt(currentUserId);
+      const assignedTodos = todos.filter(todo => todo.assignedToId === userIdNum);
+      const otherTodos = todos.filter(todo => todo.assignedToId !== userIdNum);
+      
+      return NextResponse.json([...assignedTodos, ...otherTodos]);
+    }
+
     return NextResponse.json(todos);
   } catch (error) {
     return NextResponse.json({ error: 'Todoの取得に失敗しました' }, { status: 500 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { useState, useEffect } from 'react';
-import TodoForm from './components/TodoForm';
 import { useRouter } from 'next/navigation';
 import { Todo } from './types/todo';
 
@@ -15,7 +14,13 @@ export default function Home() {
 
   const fetchTodos = async () => {
     try {
-      const response = await fetch('/api/todos');
+      // 現在のユーザーIDを取得してクエリパラメータとして送信
+      let url = '/api/todos';
+      if (currentUser?.id) {
+        url += `?currentUserId=${currentUser.id}`;
+      }
+      
+      const response = await fetch(url);
       if (!response.ok) {
         throw new Error('Todoの取得に失敗しました');
       }
@@ -76,9 +81,14 @@ export default function Home() {
         console.error('ユーザー情報の解析エラー:', error);
       }
     }
-    
-    fetchTodos();
   }, [router]);
+
+  // currentUserが設定された後にTodoを取得
+  useEffect(() => {
+    if (isLoggedIn && currentUser) {
+      fetchTodos();
+    }
+  }, [currentUser, isLoggedIn]);
 
   // ログインしていない場合は何も表示しない（リダイレクト中）
   if (!isLoggedIn) {
@@ -112,50 +122,70 @@ export default function Home() {
         </div>
       </div>
       
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">新しいTodoを作成</h2>
-        <TodoForm onTodoCreated={fetchTodos} />
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-semibold">Todo一覧</h2>
+        <button
+          onClick={() => router.push('/todos/create')}
+          className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          新規作成
+        </button>
       </div>
-
+      
       <div>
-        <h2 className="text-xl font-semibold mb-4">Todo一覧</h2>
         {isLoading ? (
           <p>読み込み中...</p>
         ) : todos.length === 0 ? (
           <p>Todoがありません</p>
         ) : (
           <ul className="space-y-4">
-            {todos.map((todo) => (
-              <li
-                key={todo.id}
-                className="border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow"
-              >
-                <div className="flex justify-between items-start">
-                  <div className="flex-1 cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
-                    <h3 className="text-lg font-medium">{todo.title}</h3>
-                    {todo.description && (
-                      <p className="text-gray-600 mt-2">{todo.description}</p>
-                    )}
-                    <div className="text-sm text-gray-500 mt-2">
-                      <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
-                      <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
-                      {todo.createdBy && (
-                        <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
+            {todos.map((todo) => {
+              const isAssignedToCurrentUser = currentUser && todo.assignedTo?.id === currentUser.id;
+              return (
+                <li
+                  key={todo.id}
+                  className={`border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${
+                    isAssignedToCurrentUser 
+                      ? 'bg-blue-50 border-blue-200' 
+                      : 'bg-white'
+                  }`}
+                >
+                  <div className="flex justify-between items-start">
+                    <div className="flex-1 cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
+                      <div className="flex items-center gap-2 mb-1">
+                        {isAssignedToCurrentUser && (
+                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                            👤 担当中
+                          </span>
+                        )}
+                        <h3 className="text-lg font-medium">{todo.title}</h3>
+                      </div>
+                      {todo.description && (
+                        <p className="text-gray-600 mt-2">{todo.description}</p>
                       )}
-                      {todo.assignedTo && (
-                        <p>担当者: {todo.assignedTo.name || todo.assignedTo.email}</p>
-                      )}
+                      <div className="text-sm text-gray-500 mt-2">
+                        <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
+                        <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
+                        {todo.createdBy && (
+                          <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
+                        )}
+                        {todo.assignedTo && (
+                          <p className={isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}>
+                            担当者: {todo.assignedTo.name || todo.assignedTo.email}
+                          </p>
+                        )}
+                      </div>
                     </div>
+                    <button
+                      onClick={() => handleDelete(todo.id)}
+                      className="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                    >
+                      削除
+                    </button>
                   </div>
-                  <button
-                    onClick={() => handleDelete(todo.id)}
-                    className="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-                  >
-                    削除
-                  </button>
-                </div>
-              </li>
-            ))}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>

--- a/app/todos/create/page.tsx
+++ b/app/todos/create/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import TodoForm from '../../components/TodoForm';
+
+export default function CreateTodoPage() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    // 認証状態チェック
+    const loggedIn = localStorage.getItem('isLoggedIn') === 'true';
+    const userStr = localStorage.getItem('user');
+    
+    setIsLoggedIn(loggedIn);
+    
+    if (!loggedIn) {
+      router.push('/login');
+      return;
+    }
+    
+    // ユーザー情報の取得
+    if (userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setCurrentUser(user);
+      } catch (error) {
+        console.error('ユーザー情報の解析エラー:', error);
+      }
+    }
+  }, [router]);
+
+  const handleTodoCreated = () => {
+    // TODO作成後はメインページに戻る
+    router.push('/');
+  };
+
+  const handleCancel = () => {
+    // キャンセル時もメインページに戻る
+    router.push('/');
+  };
+
+  // ログインしていない場合は何も表示しない（リダイレクト中）
+  if (!isLoggedIn) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>ログインページにリダイレクトしています...</p>
+    </div>;
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex justify-between items-center mb-8">
+          <h1 className="text-3xl font-bold">新しいTodoを作成</h1>
+          <div className="flex items-center space-x-4">
+            {currentUser && (
+              <div className="text-sm text-gray-600">
+                <span className="font-medium">ログイン中: </span>
+                <span className="text-gray-900">
+                  {currentUser.name || currentUser.email}
+                </span>
+                {currentUser.name && (
+                  <span className="text-gray-500 ml-1">({currentUser.email})</span>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+        
+        <div className="bg-white rounded-lg shadow-sm border p-6">
+          <TodoForm onTodoCreated={handleTodoCreated} />
+          
+          <div className="mt-6 pt-4 border-t">
+            <button
+              onClick={handleCancel}
+              className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+            >
+              キャンセル
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- メインページからTODO作成セクションを削除し、すっきりとした一覧画面を実現
- 専用の新規作成ボタンから独立したTODO作成ページ(/todos/create)に遷移
- 自分が担当のタスクを優先的に上位表示する機能を実装
- 担当タスクを視覚的に区別（青い背景と👤担当中バッジ）

## 主な変更内容
### UI/UX改善
- メインページの一覧画面をすっきりさせ、新規作成ボタンを右上に配置
- 新規作成専用ページの作成で、フォームが見やすく操作しやすくなった
- 作成完了後は自動的にメインページに戻る

### 機能強化
- APIエンドポイントでcurrentUserIdクエリパラメータを受け取り、担当タスクを優先表示
- 担当タスクには青い背景色と「👤 担当中」バッジを表示
- 担当者情報も強調表示して分かりやすく

## テスト状況
TEST.mdに従ってMCP Playwrightで完全なE2Eテストを実行し、すべて成功：
- ✅ Docker環境でのアプリケーション起動確認
- ✅ ログイン画面の表示確認
- ✅ admin/testユーザーでのログイン成功
- ✅ 新規作成機能とページ遷移の動作確認
- ✅ Todo作成・削除機能の動作確認
- ✅ 優先表示機能と視覚的区別の確認
- ✅ 無効なログイン試行でのエラーハンドリング
- ✅ データベースでのパスワードハッシュ化確認

## Test plan
- [x] 新規作成ボタンから/todos/createページに遷移
- [x] Todo作成後にメインページに戻る
- [x] 担当タスクが上位に表示される
- [x] 担当タスクに👤担当中バッジが表示される
- [x] キャンセルボタンでメインページに戻る
- [x] 既存のTodo編集・削除機能が正常動作

🤖 Generated with [Claude Code](https://claude.ai/code)