### PR TITLE
一覧画面UX改善とステータス管理機能の実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -23,7 +23,8 @@
       "mcp__playwright__browser_handle_dialog",
       "Bash(curl:*)",
       "mcp__playwright__browser_select_option",
-      "Bash(mkdir:*)"
+      "Bash(mkdir:*)",
+      "mcp__playwright__browser_wait_for"
     ],
     "deny": []
   }

--- a/app/components/TodoForm.tsx
+++ b/app/components/TodoForm.tsx
@@ -17,6 +17,7 @@ interface TodoFormProps {
     title: string;
     description: string;
     assignedToId?: number | null;
+    completed?: boolean;
   };
   isEditMode?: boolean;
   onTodoUpdated?: () => void;
@@ -33,6 +34,7 @@ export default function TodoForm({
   const [title, setTitle] = useState(initialData?.title || '');
   const [description, setDescription] = useState(initialData?.description || '');
   const [assignedToId, setAssignedToId] = useState<number | null>(initialData?.assignedToId || null);
+  const [completed, setCompleted] = useState(initialData?.completed || false);
   const [users, setUsers] = useState<User[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -70,7 +72,7 @@ export default function TodoForm({
             title, 
             description, 
             assignedToId: assignedToId || null,
-            completed: false 
+            completed: completed 
           }),
         });
 
@@ -114,6 +116,7 @@ export default function TodoForm({
         setTitle('');
         setDescription('');
         setAssignedToId(null);
+        setCompleted(false);
         onTodoCreated();
       }
     } catch (error) {
@@ -193,6 +196,22 @@ export default function TodoForm({
           ))}
         </select>
       </div>
+      {isEditMode && (
+        <div>
+          <label htmlFor="status" className="block text-sm font-medium text-gray-700">
+            ステータス
+          </label>
+          <select
+            id="status"
+            value={completed ? 'completed' : 'pending'}
+            onChange={(e) => setCompleted(e.target.value === 'completed')}
+            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+          >
+            <option value="pending">未完了</option>
+            <option value="completed">完了</option>
+          </select>
+        </div>
+      )}
       <div className="flex space-x-4">
         <button
           type="submit"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,23 +34,6 @@ export default function Home() {
     }
   };
 
-  const handleDelete = async (id: number) => {
-    try {
-      const response = await fetch(`/api/todos/${id}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) {
-        throw new Error('Todoの削除に失敗しました');
-      }
-
-      // 削除成功後、Todo一覧を更新
-      fetchTodos();
-    } catch (error) {
-      console.error('Error:', error);
-      alert('Todoの削除に失敗しました');
-    }
-  };
 
   const handleLogout = () => {
     localStorage.removeItem('isLoggedIn');
@@ -150,38 +133,35 @@ export default function Home() {
                       : 'bg-white'
                   }`}
                 >
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1 cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
-                      <div className="flex items-center gap-2 mb-1">
-                        {isAssignedToCurrentUser && (
-                          <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                            👤 担当中
-                          </span>
-                        )}
-                        <h3 className="text-lg font-medium">{todo.title}</h3>
-                      </div>
-                      {todo.description && (
-                        <p className="text-gray-600 mt-2">{todo.description}</p>
+                  <div className="cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
+                    <div className="flex items-center gap-2 mb-1">
+                      {isAssignedToCurrentUser && (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                          👤 担当中
+                        </span>
                       )}
-                      <div className="text-sm text-gray-500 mt-2">
-                        <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
-                        <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
-                        {todo.createdBy && (
-                          <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
-                        )}
-                        {todo.assignedTo && (
-                          <p className={isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}>
-                            担当者: {todo.assignedTo.name || todo.assignedTo.email}
-                          </p>
-                        )}
-                      </div>
+                      {todo.completed && (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                          ✅ 完了
+                        </span>
+                      )}
+                      <h3 className="text-lg font-medium">{todo.title}</h3>
                     </div>
-                    <button
-                      onClick={() => handleDelete(todo.id)}
-                      className="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
-                    >
-                      削除
-                    </button>
+                    {todo.description && (
+                      <p className="text-gray-600 mt-2">{todo.description}</p>
+                    )}
+                    <div className="text-sm text-gray-500 mt-2">
+                      <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
+                      <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
+                      {todo.createdBy && (
+                        <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
+                      )}
+                      {todo.assignedTo && (
+                        <p className={isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}>
+                          担当者: {todo.assignedTo.name || todo.assignedTo.email}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </li>
               );

--- a/app/todos/[id]/page.tsx
+++ b/app/todos/[id]/page.tsx
@@ -105,6 +105,7 @@ export default function TodoDetail({ params }: { params: { id: string } }) {
                   title: todo.title,
                   description: todo.description || '',
                   assignedToId: todo.assignedToId,
+                  completed: todo.completed,
                 }}
                 isEditMode={true}
                 todoId={params.id}


### PR DESCRIPTION
## Summary
一覧画面から削除ボタンを削除し、編集画面でステータス操作ができるように改善しました。

### 主な変更内容

#### 1. 一覧画面のUX改善
- **削除ボタンの削除**: 一覧画面から削除ボタンを削除し、よりクリーンなUIを実現
- **完了バッジの追加**: 完了したタスクに「✅ 完了」バッジを表示
- **安全性向上**: 削除は詳細画面からのみ可能にし、誤操作を防止

#### 2. ステータス管理機能の実装
- **編集画面でのステータス操作**: 編集モードでステータス（未完了/完了）を選択可能
- **既存フィールドの活用**: データベースの既存`completed`フィールドを活用
- **直感的なUI**: ドロップダウンで簡単にステータス変更が可能

#### 3. 視覚的な改善
- **バッジシステム**: 担当中（👤 担当中）と完了（✅ 完了）のバッジを併用表示
- **情報の整理**: 一覧画面で重要な情報が一目で分かりやすく

## 技術的な実装

### フロントエンド変更
- `app/page.tsx`: 削除ボタンの削除、完了バッジの追加
- `app/components/TodoForm.tsx`: ステータス選択フィールドの追加（編集モードのみ）
- `app/todos/[id]/page.tsx`: 編集フォームにcompletedフィールドを渡すよう修正

### API対応
- 既存のAPIエンドポイント（`/api/todos/[id]`）は既に`completed`フィールドに対応済み
- 新しいフィールド追加は不要

## テスト結果
✅ 手動テストですべての機能を確認済み：
- 一覧画面からの削除ボタン削除
- 編集画面でのステータス変更機能
- 完了バッジの正常表示
- 既存機能への影響なし

## UI/UX改善効果
- **操作の安全性**: 一覧からの誤削除を防止
- **視認性向上**: ステータスが一目で分かりやすく
- **操作効率**: 編集画面でステータス変更が簡単に
- **直感的**: バッジによる視覚的フィードバック

## Test plan
- [x] 一覧画面から削除ボタンが削除されている
- [x] 編集画面でステータス選択が可能
- [x] ステータス変更が正常に保存される
- [x] 完了タスクに✅完了バッジが表示される
- [x] 既存の担当中バッジと併用表示される
- [x] 詳細画面での削除機能は維持される

🤖 Generated with [Claude Code](https://claude.ai/code)