### PR TITLE
一覧画面のレイアウト改善: 担当者表示と横幅効率化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,40 +135,49 @@ export default function Home() {
                   }`}
                 >
                   <div className="cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
-                    <div className="flex items-center gap-2 mb-1">
-                      {isAssignedToCurrentUser && (
-                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                          👤 担当中
-                        </span>
-                      )}
-                      {todo.completed && (
-                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                          ✅ 完了
-                        </span>
-                      )}
-                      <h3 className="text-lg font-medium">{todo.title}</h3>
-                    </div>
-                    {todo.description && (
-                      <p className="text-gray-600 mt-2">{todo.description}</p>
-                    )}
-                    {todo.labels && todo.labels.length > 0 && (
-                      <div className="flex flex-wrap gap-1 mt-2">
-                        {todo.labels.map((labelRelation) => (
-                          <LabelBadge key={labelRelation.label.id} label={labelRelation.label} />
-                        ))}
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          {isAssignedToCurrentUser && (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                              👤 担当中
+                            </span>
+                          )}
+                          {todo.completed && (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                              ✅ 完了
+                            </span>
+                          )}
+                          <h3 className="text-lg font-medium">{todo.title}</h3>
+                        </div>
+                        {todo.description && (
+                          <p className="text-gray-600 mt-1 mb-2">{todo.description}</p>
+                        )}
+                        {todo.labels && todo.labels.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mb-2">
+                            {todo.labels.map((labelRelation) => (
+                              <LabelBadge key={labelRelation.label.id} label={labelRelation.label} />
+                            ))}
+                          </div>
+                        )}
                       </div>
-                    )}
-                    <div className="text-sm text-gray-500 mt-2">
-                      <p>作成日: {new Date(todo.createdAt).toLocaleString()}</p>
-                      <p>更新日: {new Date(todo.updatedAt).toLocaleString()}</p>
-                      {todo.createdBy && (
-                        <p>作成者: {todo.createdBy.name || todo.createdBy.email}</p>
-                      )}
-                      {todo.assignedTo && (
-                        <p className={isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}>
-                          担当者: {todo.assignedTo.name || todo.assignedTo.email}
-                        </p>
-                      )}
+                      <div className="text-xs text-gray-500 text-right ml-4 flex-shrink-0">
+                        {todo.assignedTo && (
+                          <div className={`mb-1 ${isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}`}>
+                            担当: {todo.assignedTo.name || todo.assignedTo.email}
+                          </div>
+                        )}
+                        <div>作成: {todo.createdBy?.name || todo.createdBy?.email || '不明'}</div>
+                      </div>
+                    </div>
+                    <div className="flex justify-between items-center text-xs text-gray-400">
+                      <div className="flex gap-4">
+                        <span>作成: {new Date(todo.createdAt).toLocaleDateString()}</span>
+                        <span>更新: {new Date(todo.updatedAt).toLocaleDateString()}</span>
+                      </div>
+                      <div className="text-right">
+                        {new Date(todo.updatedAt).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
+                      </div>
                     </div>
                   </div>
                 </li>


### PR DESCRIPTION
## Summary
Todo一覧画面のレイアウトを大幅に改善し、情報の視認性と画面の使用効率を向上させました。

## 主な改善点

### 🎨 レイアウト構造の最適化
- **左右分割レイアウト**: メイン情報（左）と担当者・作成者情報（右）に分離
- **縦幅の削減**: 日時情報を横並びに配置してコンパクト化
- **横幅の有効活用**: 画面の横スペースを効率的に使用

### 👥 担当者情報の強化
- **担当者表示**: 右上に「担当: ユーザー名」として明確に表示
- **作成者表示**: 右側に「作成: 作成者名」として配置
- **視覚的区別**: 担当中のタスクは青色でハイライト

### 📅 日時情報の最適化
- **横並び配置**: 「作成: 日付 更新: 日付」形式で横に配列
- **時刻表示**: 右端に更新時刻を簡潔に表示
- **フォントサイズ**: より小さなフォントで情報密度を向上

## レイアウト比較

### Before (縦積み)
```
タイトル
説明文
ラベル
作成日: 2025/7/6 15:16:00
更新日: 2025/7/6 15:16:00
作成者: 管理者
担当者: テストユーザー
```

### After (効率的配置)
```
┌─────────────────────────────────────────────┐
│ [ステータス] タイトル           担当: ユーザー │
│ 説明文                         作成: 作成者  │
│ [ラベル1] [ラベル2]                        │
│ 作成:7/6  更新:7/6                15:16   │
└─────────────────────────────────────────────┘
```

## 技術実装
- **Flexboxレイアウト**: `justify-between`で左右に情報を配置
- **レスポンシブ対応**: `flex-1`と`flex-shrink-0`で適切な伸縮
- **条件付きスタイル**: 担当中タスクの特別表示

## テスト済み
✅ 担当者ありTodoの表示確認
✅ 担当者なしTodoの表示確認  
✅ ラベル表示との併用確認
✅ ステータスバッジとの共存確認
✅ レスポンシブ動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)