### PR TITLE
パスワード変更機能とプロフィール設定画面を実装

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "mcp__playwright__browser_select_option",
       "Bash(mkdir:*)",
       "mcp__playwright__browser_wait_for",
-      "Bash(./scripts/migrate-dev.sh:*)"
+      "Bash(./scripts/migrate-dev.sh:*)",
+      "Bash(git pull:*)"
     ],
     "deny": []
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/app/api/users/password/route.ts
+++ b/app/api/users/password/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/app/lib/prisma';
+import { verifyPassword, hashPassword } from '@/app/lib/password';
+import { validatePassword } from '@/app/lib/password-validation';
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { userId, currentPassword, newPassword } = body;
+
+    // 入力値検証
+    if (!userId || !currentPassword || !newPassword) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'ユーザーID、現在のパスワード、新しいパスワードを入力してください',
+        },
+        { status: 400 }
+      );
+    }
+
+    // パスワード強度チェック
+    const passwordValidation = validatePassword(newPassword);
+    if (!passwordValidation.isValid) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: passwordValidation.errors[0] || 'パスワードの形式が正しくありません',
+        },
+        { status: 400 }
+      );
+    }
+
+    // 現在のパスワードと新しいパスワードが同じかチェック
+    if (currentPassword === newPassword) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: '現在のパスワードと新しいパスワードが同じです',
+        },
+        { status: 400 }
+      );
+    }
+
+    // データベースからユーザーを取得
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        email: true,
+        password: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'ユーザーが見つかりません',
+        },
+        { status: 404 }
+      );
+    }
+
+    // 現在のパスワードを検証
+    const isCurrentPasswordValid = await verifyPassword(currentPassword, user.password);
+    if (!isCurrentPasswordValid) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: '現在のパスワードが正しくありません',
+        },
+        { status: 401 }
+      );
+    }
+
+    // 新しいパスワードをハッシュ化
+    const hashedNewPassword = await hashPassword(newPassword);
+
+    // データベースのパスワードを更新
+    await prisma.user.update({
+      where: { id: userId },
+      data: { password: hashedNewPassword },
+    });
+
+    console.log('パスワード変更成功:', { userId, email: user.email });
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: 'パスワードが正常に変更されました',
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('パスワード変更APIエラー:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'サーバーエラーが発生しました',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/lib/password-validation.ts
+++ b/app/lib/password-validation.ts
@@ -1,0 +1,92 @@
+export interface PasswordValidationResult {
+  isValid: boolean;
+  errors: string[];
+  strength: 'weak' | 'medium' | 'strong';
+}
+
+export function validatePassword(password: string): PasswordValidationResult {
+  const errors: string[] = [];
+  let strength: 'weak' | 'medium' | 'strong' = 'weak';
+
+  // 最小文字数チェック
+  if (password.length < 6) {
+    errors.push('パスワードは6文字以上で入力してください');
+  }
+
+  // 最大文字数チェック（DoS攻撃対策）
+  if (password.length > 128) {
+    errors.push('パスワードは128文字以下で入力してください');
+  }
+
+  // 文字種チェック
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasNumbers = /\d/.test(password);
+  const hasSpecialChars = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+
+  let complexityScore = 0;
+  if (hasLowerCase) complexityScore++;
+  if (hasUpperCase) complexityScore++;
+  if (hasNumbers) complexityScore++;
+  if (hasSpecialChars) complexityScore++;
+
+  // 推奨事項（エラーではない）
+  if (password.length >= 8) {
+    if (complexityScore >= 3) {
+      strength = 'strong';
+    } else if (complexityScore >= 2) {
+      strength = 'medium';
+    }
+  } else if (complexityScore >= 2) {
+    strength = 'medium';
+  }
+
+  // 一般的な弱いパスワードパターンをチェック
+  const weakPatterns = [
+    /^(.)\1{5,}$/, // 同じ文字の繰り返し
+    /^123456/, // 連続した数字
+    /^password/i, // "password" で始まる
+    /^qwerty/i, // "qwerty" で始まる
+    /^abc123/i, // よくある組み合わせ
+  ];
+
+  for (const pattern of weakPatterns) {
+    if (pattern.test(password)) {
+      errors.push('より安全なパスワードを設定してください');
+      strength = 'weak';
+      break;
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    strength,
+  };
+}
+
+export function getPasswordStrengthMessage(strength: 'weak' | 'medium' | 'strong'): string {
+  switch (strength) {
+    case 'weak':
+      return 'パスワード強度: 弱い';
+    case 'medium':
+      return 'パスワード強度: 普通';
+    case 'strong':
+      return 'パスワード強度: 強い';
+    default:
+      return '';
+  }
+}
+
+export function getPasswordStrengthColor(strength: 'weak' | 'medium' | 'strong'): string {
+  switch (strength) {
+    case 'weak':
+      return 'text-red-600';
+    case 'medium':
+      return 'text-yellow-600';
+    case 'strong':
+      return 'text-green-600';
+    default:
+      return 'text-gray-600';
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,6 +98,12 @@ export default function Home() {
             </div>
           )}
           <button
+            onClick={() => router.push('/profile')}
+            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            プロフィール設定
+          </button>
+          <button
             onClick={handleLogout}
             className="inline-flex justify-center rounded-md border border-transparent bg-gray-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
           >

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { validatePassword, getPasswordStrengthMessage, getPasswordStrengthColor } from '@/app/lib/password-validation';
+
+export default function ProfilePage() {
+  const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [messageType, setMessageType] = useState<'success' | 'error'>('success');
+  const [showPasswords, setShowPasswords] = useState(false);
+  const [passwordValidation, setPasswordValidation] = useState(validatePassword(''));
+  const router = useRouter();
+
+  useEffect(() => {
+    // 認証状態チェック
+    const loggedIn = localStorage.getItem('isLoggedIn') === 'true';
+    const userStr = localStorage.getItem('user');
+    
+    setIsLoggedIn(loggedIn);
+    
+    if (!loggedIn) {
+      router.push('/login');
+      return;
+    }
+    
+    // ユーザー情報の取得
+    if (userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setCurrentUser(user);
+      } catch (error) {
+        console.error('ユーザー情報の解析エラー:', error);
+      }
+    }
+  }, [router]);
+
+  // パスワード強度をリアルタイムで更新
+  useEffect(() => {
+    if (newPassword) {
+      setPasswordValidation(validatePassword(newPassword));
+    } else {
+      setPasswordValidation(validatePassword(''));
+    }
+  }, [newPassword]);
+
+  const handlePasswordChange = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!currentUser) {
+      setMessage('ユーザー情報が取得できませんでした');
+      setMessageType('error');
+      return;
+    }
+
+    // フォームバリデーション
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      setMessage('すべての項目を入力してください');
+      setMessageType('error');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setMessage('新しいパスワードと確認パスワードが一致しません');
+      setMessageType('error');
+      return;
+    }
+
+    if (!passwordValidation.isValid) {
+      setMessage(passwordValidation.errors[0] || 'パスワードの形式が正しくありません');
+      setMessageType('error');
+      return;
+    }
+
+    setIsLoading(true);
+    setMessage('');
+
+    try {
+      const response = await fetch('/api/users/password', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: currentUser.id,
+          currentPassword,
+          newPassword,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (response.ok && data.success) {
+        setMessage('パスワードが正常に変更されました');
+        setMessageType('success');
+        // フォームをリセット
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+      } else {
+        setMessage(data.message || 'パスワードの変更に失敗しました');
+        setMessageType('error');
+      }
+    } catch (error) {
+      console.error('パスワード変更エラー:', error);
+      setMessage('サーバーエラーが発生しました');
+      setMessageType('error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('user');
+    router.push('/login');
+  };
+
+  // ログインしていない場合は何も表示しない（リダイレクト中）
+  if (!isLoggedIn) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>ログインページにリダイレクトしています...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* ナビゲーションバー */}
+      <nav className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <button
+                onClick={() => router.push('/')}
+                className="text-indigo-600 hover:text-indigo-700 font-medium"
+              >
+                ← Todo一覧に戻る
+              </button>
+            </div>
+            <div className="flex items-center space-x-4">
+              {currentUser && (
+                <div className="text-sm text-gray-600">
+                  <span className="font-medium">ログイン中: </span>
+                  <span className="text-gray-900">
+                    {currentUser.name || currentUser.email}
+                  </span>
+                </div>
+              )}
+              <button
+                onClick={handleLogout}
+                className="inline-flex justify-center rounded-md border border-transparent bg-gray-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+              >
+                ログアウト
+              </button>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* メインコンテンツ */}
+      <div className="max-w-3xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">プロフィール設定</h1>
+          <p className="mt-2 text-gray-600">アカウント情報とパスワードの変更</p>
+        </div>
+
+        {/* ユーザー情報 */}
+        <div className="bg-white shadow rounded-lg mb-8">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-medium text-gray-900">ユーザー情報</h2>
+          </div>
+          <div className="px-6 py-4">
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700">メールアドレス</label>
+                <div className="mt-1">
+                  <input
+                    type="email"
+                    value={currentUser?.email || ''}
+                    disabled
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-gray-50 text-gray-600 sm:text-sm"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700">名前</label>
+                <div className="mt-1">
+                  <input
+                    type="text"
+                    value={currentUser?.name || ''}
+                    disabled
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm bg-gray-50 text-gray-600 sm:text-sm"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* パスワード変更 */}
+        <div className="bg-white shadow rounded-lg">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-medium text-gray-900">パスワード変更</h2>
+          </div>
+          <div className="px-6 py-4">
+            {message && (
+              <div className={`mb-6 px-4 py-3 rounded ${
+                messageType === 'success' 
+                  ? 'bg-green-50 border border-green-200 text-green-700' 
+                  : 'bg-red-50 border border-red-200 text-red-700'
+              }`}>
+                {message}
+              </div>
+            )}
+            
+            <form onSubmit={handlePasswordChange} className="space-y-6">
+              <div>
+                <label htmlFor="currentPassword" className="block text-sm font-medium text-gray-700">
+                  現在のパスワード
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="currentPassword"
+                    name="currentPassword"
+                    type={showPasswords ? 'text' : 'password'}
+                    value={currentPassword}
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    placeholder="現在のパスワード"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="newPassword" className="block text-sm font-medium text-gray-700">
+                  新しいパスワード
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="newPassword"
+                    name="newPassword"
+                    type={showPasswords ? 'text' : 'password'}
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    placeholder="新しいパスワード（6文字以上）"
+                  />
+                </div>
+                {newPassword && (
+                  <div className="mt-2">
+                    <div className={`text-sm ${getPasswordStrengthColor(passwordValidation.strength)}`}>
+                      {getPasswordStrengthMessage(passwordValidation.strength)}
+                    </div>
+                    {passwordValidation.errors.length > 0 && (
+                      <div className="mt-1 text-sm text-red-600">
+                        <ul className="list-disc list-inside">
+                          {passwordValidation.errors.map((error, index) => (
+                            <li key={index}>{error}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+                  新しいパスワード（確認）
+                </label>
+                <div className="mt-1">
+                  <input
+                    id="confirmPassword"
+                    name="confirmPassword"
+                    type={showPasswords ? 'text' : 'password'}
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                    placeholder="新しいパスワード（確認）"
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center">
+                <input
+                  id="showPasswords"
+                  name="showPasswords"
+                  type="checkbox"
+                  checked={showPasswords}
+                  onChange={(e) => setShowPasswords(e.target.checked)}
+                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
+                />
+                <label htmlFor="showPasswords" className="ml-2 block text-sm text-gray-900">
+                  パスワードを表示
+                </label>
+              </div>
+
+              <div>
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isLoading ? '変更中...' : 'パスワードを変更'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- パスワード変更用APIエンドポイント（PUT /api/users/password）を実装
- プロフィール設定画面（/profile）を実装
- リアルタイムパスワード強度検証機能を追加
- セキュリティ強化（bcrypt、入力検証、弱いパスワードチェック）
- メインナビゲーションにプロフィール設定リンクを追加

## 機能詳細
### APIエンドポイント
- **パスワード変更API**: 現在のパスワード検証、新しいパスワードのハッシュ化、セキュリティチェック
- **バリデーション**: 最小6文字、最大128文字、弱いパスワードパターンチェック

### プロフィール設定画面
- **ユーザー情報表示**: メールアドレスと名前の表示（読み取り専用）
- **パスワード変更フォーム**: 現在のパスワード、新しいパスワード、確認パスワード
- **リアルタイム強度表示**: 弱い・普通・強いの3段階表示
- **パスワード表示機能**: チェックボックスでパスワードの可視性を切り替え

### セキュリティ機能
- **パスワード強度検証**: 文字種の複雑さと長さに基づく評価
- **弱いパスワードチェック**: 一般的な弱いパターンの検出
- **現在のパスワード確認**: 変更前の認証必須
- **bcryptハッシュ化**: セキュアなパスワード保存

## Test plan
- [x] Playwrightを使用したE2Eテスト実行済み
- [x] パスワード強度検証のテスト（弱い→普通→強い）
- [x] バリデーションエラーメッセージの表示確認
- [x] パスワード変更の成功フロー確認
- [x] フォームリセット機能の確認
- [x] パスワード表示機能のテスト
- [x] ナビゲーション機能のテスト

🤖 Generated with [Claude Code](https://claude.ai/code)