### PR TITLE
Redmine風プロジェクト前提TODOアプリに変更

### DIFF
--- a/app/api/__tests__/test-utils.ts
+++ b/app/api/__tests__/test-utils.ts
@@ -316,8 +316,24 @@ export const PrismaQueries = {
           label: true,
         },
       },
+      project: {
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          color: true,
+          createdBy: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+      },
     },
     orderBy: { createdAt: 'desc' as const },
+    where: {},
   },
 
   LABEL_ORDER_BY_NAME: {

--- a/app/api/todos/id/route.test.ts
+++ b/app/api/todos/id/route.test.ts
@@ -52,6 +52,7 @@ describe('Todo API (特定のID)', () => {
           description: '更新された説明',
           completed: true,
           assignedToId: undefined,
+          projectId: undefined,
           labels: undefined,
         },
         include: {
@@ -67,6 +68,21 @@ describe('Todo API (特定のID)', () => {
               id: true,
               name: true,
               email: true,
+            },
+          },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
             },
           },
           labels: {

--- a/app/api/todos/route.test.ts
+++ b/app/api/todos/route.test.ts
@@ -211,6 +211,7 @@ describe('Todo API', () => {
         body: JSON.stringify({
           title: '新しいTodo',
           description: '説明',
+          projectId: 1,
         }),
       });
 
@@ -230,6 +231,7 @@ describe('Todo API', () => {
           description: '説明',
           createdById: undefined,
           assignedToId: undefined,
+          projectId: 1,
           labels: undefined,
         },
         include: {
@@ -250,6 +252,21 @@ describe('Todo API', () => {
           labels: {
             include: {
               label: true,
+            },
+          },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
             },
           },
         },
@@ -302,6 +319,7 @@ describe('Todo API', () => {
           title: 'ラベル付きTodo',
           description: 'ラベルが割り当てられたTodo',
           createdById: 1,
+          projectId: 1,
           labelIds: [1, 2],
         }),
       });
@@ -322,6 +340,7 @@ describe('Todo API', () => {
           description: 'ラベルが割り当てられたTodo',
           createdById: 1,
           assignedToId: undefined,
+          projectId: 1,
           labels: {
             create: [
               { labelId: 1 },
@@ -347,6 +366,21 @@ describe('Todo API', () => {
           labels: {
             include: {
               label: true,
+            },
+          },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
             },
           },
         },
@@ -391,6 +425,7 @@ describe('Todo API', () => {
           description: 'ユーザーが割り当てられたTodo',
           createdById: 1,
           assignedToId: 2,
+          projectId: 1,
         }),
       });
 
@@ -410,6 +445,7 @@ describe('Todo API', () => {
           description: 'ユーザーが割り当てられたTodo',
           createdById: 1,
           assignedToId: 2,
+          projectId: 1,
           labels: undefined,
         },
         include: {
@@ -430,6 +466,21 @@ describe('Todo API', () => {
           labels: {
             include: {
               label: true,
+            },
+          },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
             },
           },
         },
@@ -477,6 +528,7 @@ describe('Todo API', () => {
           description: 'ラベルとユーザー割り当ての両方を含むTodo',
           createdById: 1,
           assignedToId: 2,
+          projectId: 1,
           labelIds: [1],
         }),
       });
@@ -497,6 +549,7 @@ describe('Todo API', () => {
           description: 'ラベルとユーザー割り当ての両方を含むTodo',
           createdById: 1,
           assignedToId: 2,
+          projectId: 1,
           labels: {
             create: [
               { labelId: 1 }
@@ -521,6 +574,21 @@ describe('Todo API', () => {
           labels: {
             include: {
               label: true,
+            },
+          },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
             },
           },
         },
@@ -569,6 +637,7 @@ describe('Todo API', () => {
           title: '空ラベルTodo',
           description: '空のラベル配列を持つTodo',
           createdById: 1,
+          projectId: 1,
           labelIds: [],
         }),
       });
@@ -584,6 +653,7 @@ describe('Todo API', () => {
           description: '空のラベル配列を持つTodo',
           createdById: 1,
           assignedToId: undefined,
+          projectId: 1,
           labels: undefined,
         },
         include: {
@@ -606,6 +676,21 @@ describe('Todo API', () => {
               label: true,
             },
           },
+          project: {
+            select: {
+              id: true,
+              name: true,
+              description: true,
+              color: true,
+              createdBy: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                },
+              },
+            },
+          },
         },
       });
       expect(data.labels).toEqual([]);
@@ -621,6 +706,7 @@ describe('Todo API', () => {
         body: JSON.stringify({
           title: '新しいTodo',
           description: '説明',
+          projectId: 1,
         }),
       });
 

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -16,8 +16,12 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const currentUserId = searchParams.get('currentUserId');
+    const projectId = searchParams.get('projectId');
     
     const todos = await prisma.todo.findMany({
+      where: projectId ? {
+        projectId: parseInt(projectId)
+      } : {},
       include: {
         createdBy: {
           select: {
@@ -83,6 +87,13 @@ export async function POST(request: Request) {
     if (!title) {
       return NextResponse.json(
         { error: 'タイトルは必須です' },
+        { status: 400 }
+      );
+    }
+
+    if (!projectId) {
+      return NextResponse.json(
+        { error: 'プロジェクトIDは必須です' },
         { status: 400 }
       );
     }

--- a/app/components/TodoForm.tsx
+++ b/app/components/TodoForm.tsx
@@ -13,8 +13,10 @@ interface User {
 
 interface TodoFormProps {
   onTodoCreated: () => void;
+  onCancel?: () => void;
   onTodoDeleted?: (id: string) => void;
   todoId?: string;
+  projectId?: number;
   initialData?: {
     title: string;
     description: string;
@@ -29,8 +31,10 @@ interface TodoFormProps {
 
 export default function TodoForm({ 
   onTodoCreated, 
+  onCancel,
   onTodoDeleted, 
-  todoId, 
+  todoId,
+  projectId,
   initialData, 
   isEditMode = false, 
   onTodoUpdated 
@@ -38,7 +42,9 @@ export default function TodoForm({
   const [title, setTitle] = useState(initialData?.title || '');
   const [description, setDescription] = useState(initialData?.description || '');
   const [assignedToId, setAssignedToId] = useState<number | null>(initialData?.assignedToId || null);
-  const [projectId, setProjectId] = useState<number | null>(initialData?.projectId || null);
+  const [formProjectId, setFormProjectId] = useState<number | null>(
+    projectId || initialData?.projectId || null
+  );
   const [completed, setCompleted] = useState(initialData?.completed || false);
   const [labelIds, setLabelIds] = useState<number[]>(initialData?.labelIds || []);
   const [users, setUsers] = useState<User[]>([]);
@@ -78,7 +84,7 @@ export default function TodoForm({
             title, 
             description, 
             assignedToId: assignedToId || null,
-            projectId: projectId || null,
+            projectId: formProjectId || null,
             completed: completed,
             labelIds: labelIds
           }),
@@ -114,7 +120,7 @@ export default function TodoForm({
             description, 
             createdById,
             assignedToId: assignedToId || null,
-            projectId: projectId || null,
+            projectId: formProjectId || null,
             labelIds: labelIds
           }),
         });
@@ -126,7 +132,9 @@ export default function TodoForm({
         setTitle('');
         setDescription('');
         setAssignedToId(null);
-        setProjectId(null);
+        if (!projectId) {
+          setFormProjectId(null);
+        }
         setCompleted(false);
         setLabelIds([]);
         onTodoCreated();
@@ -224,10 +232,12 @@ export default function TodoForm({
           </select>
         </div>
       )}
-      <ProjectSelector
-        selectedProjectId={projectId}
-        onProjectChange={setProjectId}
-      />
+      {!projectId && (
+        <ProjectSelector
+          selectedProjectId={formProjectId}
+          onProjectChange={setFormProjectId}
+        />
+      )}
       <LabelSelector
         selectedLabelIds={labelIds}
         onLabelsChange={setLabelIds}
@@ -240,6 +250,15 @@ export default function TodoForm({
         >
 {isLoading ? (isEditMode ? '更新中...' : '作成中...') : (isEditMode ? 'Todoを更新' : 'Todoを作成')}
         </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            キャンセル
+          </button>
+        )}
         {todoId && (
           <button
             type="button"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,35 @@
 'use client';
 
-import React from 'react';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Todo } from './types/todo';
-import LabelBadge from './components/LabelBadge';
+import { Project } from '@/app/types/todo';
+import ProjectForm from '@/app/components/ProjectForm';
+import ProjectBadge from '@/app/components/ProjectBadge';
 
 export default function Home() {
-  const [todos, setTodos] = useState<Todo[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingProject, setEditingProject] = useState<Project | null>(null);
   const router = useRouter();
 
-  const fetchTodos = async () => {
+  const fetchProjects = async () => {
     try {
-      // 現在のユーザーIDを取得してクエリパラメータとして送信
-      let url = '/api/todos';
-      if (currentUser?.id) {
-        url += `?currentUserId=${currentUser.id}`;
-      }
-      
-      const response = await fetch(url);
+      const response = await fetch('/api/projects');
       if (!response.ok) {
-        throw new Error('Todoの取得に失敗しました');
+        throw new Error('プロジェクトの取得に失敗しました');
       }
       const data = await response.json();
-      setTodos(data);
+      setProjects(data);
     } catch (error) {
       console.error('Error:', error);
-      alert('Todoの取得に失敗しました');
+      alert('プロジェクトの取得に失敗しました');
     } finally {
       setIsLoading(false);
     }
   };
-
 
   const handleLogout = () => {
     localStorage.removeItem('isLoggedIn');
@@ -65,14 +60,33 @@ export default function Home() {
         console.error('ユーザー情報の解析エラー:', error);
       }
     }
+
+    fetchProjects();
   }, [router]);
 
-  // currentUserが設定された後にTodoを取得
-  useEffect(() => {
-    if (isLoggedIn && currentUser) {
-      fetchTodos();
-    }
-  }, [currentUser, isLoggedIn]);
+  const handleProjectCreated = () => {
+    fetchProjects();
+    setShowCreateForm(false);
+  };
+
+  const handleProjectUpdated = () => {
+    fetchProjects();
+    setEditingProject(null);
+  };
+
+  const handleProjectDeleted = (projectId: number) => {
+    setProjects(projects.filter(p => p.id !== projectId));
+    setEditingProject(null);
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
 
   // ログインしていない場合は何も表示しない（リダイレクト中）
   if (!isLoggedIn) {
@@ -83,8 +97,12 @@ export default function Home() {
 
   return (
     <main className="container mx-auto px-4 py-8">
+      {/* ヘッダー */}
       <div className="flex justify-between items-center mb-8">
-        <h1 className="text-3xl font-bold">Todoアプリ</h1>
+        <div>
+          <h1 className="text-3xl font-bold">プロジェクト選択</h1>
+          <p className="text-gray-600 mt-1">作業するプロジェクトを選択してください</p>
+        </div>
         <div className="flex items-center space-x-4">
           {currentUser && (
             <div className="text-sm text-gray-600">
@@ -97,12 +115,6 @@ export default function Home() {
               )}
             </div>
           )}
-          <button
-            onClick={() => router.push('/projects')}
-            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-          >
-            プロジェクト管理
-          </button>
           <button
             onClick={() => router.push('/profile')}
             className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
@@ -117,87 +129,114 @@ export default function Home() {
           </button>
         </div>
       </div>
-      
-      <div className="flex justify-between items-center mb-6">
-        <h2 className="text-xl font-semibold">Todo一覧</h2>
+
+      {/* アクションボタン */}
+      <div className="mb-6">
         <button
-          onClick={() => router.push('/todos/create')}
-          className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          onClick={() => setShowCreateForm(true)}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium"
         >
-          新規作成
+          新しいプロジェクトを作成
         </button>
       </div>
-      
-      <div>
+
+      {/* プロジェクト作成フォーム */}
+      {showCreateForm && (
+        <div className="mb-8">
+          <ProjectForm
+            onProjectCreated={handleProjectCreated}
+            onCancel={() => setShowCreateForm(false)}
+          />
+        </div>
+      )}
+
+      {/* プロジェクト編集フォーム */}
+      {editingProject && (
+        <div className="mb-8">
+          <ProjectForm
+            projectId={editingProject.id}
+            initialData={{
+              name: editingProject.name,
+              description: editingProject.description || '',
+              color: editingProject.color,
+            }}
+            isEditMode={true}
+            onProjectUpdated={handleProjectUpdated}
+            onProjectDeleted={handleProjectDeleted}
+            onCancel={() => setEditingProject(null)}
+          />
+        </div>
+      )}
+
+      {/* プロジェクト一覧 */}
+      <div className="bg-white rounded-lg shadow">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold">利用可能なプロジェクト</h2>
+        </div>
+
         {isLoading ? (
-          <p>読み込み中...</p>
-        ) : todos.length === 0 ? (
-          <p>Todoがありません</p>
+          <div className="p-6 text-center">
+            <p className="text-gray-500">読み込み中...</p>
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="p-6 text-center">
+            <p className="text-gray-500">まだプロジェクトがありません。</p>
+            <p className="text-gray-400 text-sm mt-1">上のボタンから新しいプロジェクトを作成してください。</p>
+          </div>
         ) : (
-          <ul className="space-y-4">
-            {todos.map((todo) => {
-              const isAssignedToCurrentUser = currentUser && todo.assignedTo?.id === currentUser.id;
-              return (
-                <li
-                  key={todo.id}
-                  className={`border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${
-                    isAssignedToCurrentUser 
-                      ? 'bg-blue-50 border-blue-200' 
-                      : 'bg-white'
-                  }`}
-                >
-                  <div className="cursor-pointer" onClick={() => router.push(`/todos/${todo.id}`)}>
-                    <div className="flex items-start justify-between mb-2">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          {isAssignedToCurrentUser && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                              👤 担当中
-                            </span>
-                          )}
-                          {todo.completed && (
-                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                              ✅ 完了
-                            </span>
-                          )}
-                          <h3 className="text-lg font-medium">{todo.title}</h3>
-                        </div>
-                        {todo.description && (
-                          <p className="text-gray-600 mt-1 mb-2">{todo.description}</p>
-                        )}
-                        {todo.labels && todo.labels.length > 0 && (
-                          <div className="flex flex-wrap gap-1 mb-2">
-                            {todo.labels.map((labelRelation) => (
-                              <LabelBadge key={labelRelation.label.id} label={labelRelation.label} />
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                      <div className="text-xs text-gray-500 text-right ml-4 flex-shrink-0">
-                        {todo.assignedTo && (
-                          <div className={`mb-1 ${isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}`}>
-                            担当: {todo.assignedTo.name || todo.assignedTo.email}
-                          </div>
-                        )}
-                        <div>作成: {todo.createdBy?.name || todo.createdBy?.email || '不明'}</div>
-                      </div>
+          <div className="divide-y divide-gray-200">
+            {projects.map((project) => (
+              <div
+                key={project.id}
+                className="p-6 hover:bg-gray-50 transition-colors cursor-pointer"
+                onClick={() => router.push(`/projects/${project.id}/todos`)}
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex-1">
+                    <div className="flex items-center space-x-3 mb-2">
+                      <ProjectBadge project={project} />
+                      <span className="text-sm text-gray-500">
+                        ID: {project.id}
+                      </span>
                     </div>
-                    <div className="flex justify-between items-center text-xs text-gray-400">
-                      <div className="flex gap-4">
-                        <span>作成: {new Date(todo.createdAt).toLocaleDateString()}</span>
-                        <span>更新: {new Date(todo.updatedAt).toLocaleDateString()}</span>
-                      </div>
-                      <div className="text-right">
-                        {new Date(todo.updatedAt).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
-                      </div>
+                    
+                    {project.description && (
+                      <p className="text-gray-600 mb-3">{project.description}</p>
+                    )}
+                    
+                    <div className="flex items-center space-x-4 text-sm text-gray-500">
+                      <span>
+                        作成日: {formatDate(project.createdAt)}
+                      </span>
+                      {project.createdBy && (
+                        <span>
+                          作成者: {project.createdBy.name || project.createdBy.email}
+                        </span>
+                      )}
+                      <span>
+                        Todo数: {(project as any)._count?.todos || 0}件
+                      </span>
                     </div>
                   </div>
-                </li>
-              );
-            })}
-          </ul>
+                  
+                  <div className="ml-4 flex items-center space-x-2">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditingProject(project);
+                      }}
+                      className="text-gray-400 hover:text-gray-600 text-sm"
+                    >
+                      設定
+                    </button>
+                    <div className="text-gray-400">→</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
         )}
       </div>
     </main>
   );
-} 
+}

--- a/app/projects/[id]/todos/[todoId]/page.tsx
+++ b/app/projects/[id]/todos/[todoId]/page.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Todo, Project } from '@/app/types/todo';
+import LabelBadge from '@/app/components/LabelBadge';
+import ProjectBadge from '@/app/components/ProjectBadge';
+
+export default function ProjectTodoDetail() {
+  const [todo, setTodo] = useState<Todo | null>(null);
+  const [project, setProject] = useState<Project | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.id as string;
+  const todoId = params.todoId as string;
+
+  const fetchProject = async () => {
+    try {
+      const response = await fetch(`/api/projects/${projectId}`);
+      if (!response.ok) {
+        throw new Error('プロジェクトの取得に失敗しました');
+      }
+      const data = await response.json();
+      setProject(data);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('プロジェクトの取得に失敗しました');
+    }
+  };
+
+  const fetchTodo = async () => {
+    try {
+      const response = await fetch(`/api/todos/${todoId}`);
+      if (!response.ok) {
+        throw new Error('Todoの取得に失敗しました');
+      }
+      const data = await response.json();
+      
+      // プロジェクトIDが一致しない場合はエラー
+      if (data.projectId !== parseInt(projectId)) {
+        throw new Error('指定されたプロジェクトにこのTodoは存在しません');
+      }
+      
+      setTodo(data);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Todoの取得に失敗しました');
+      router.push(`/projects/${projectId}/todos`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const toggleComplete = async () => {
+    if (!todo) return;
+
+    try {
+      const response = await fetch(`/api/todos/${todo.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...todo,
+          completed: !todo.completed,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Todo更新に失敗しました');
+      }
+
+      const updatedTodo = await response.json();
+      setTodo(updatedTodo);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Todo更新に失敗しました');
+    }
+  };
+
+  const deleteTodo = async () => {
+    if (!todo) return;
+
+    if (!confirm('このTodoを削除しますか？')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/todos/${todo.id}`, {
+        method: 'DELETE',
+      });
+
+      if (!response.ok) {
+        throw new Error('Todo削除に失敗しました');
+      }
+
+      alert('Todoを削除しました');
+      router.push(`/projects/${projectId}/todos`);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Todo削除に失敗しました');
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('user');
+    setIsLoggedIn(false);
+    setCurrentUser(null);
+    router.push('/login');
+  };
+
+  useEffect(() => {
+    // 認証状態チェック
+    const loggedIn = localStorage.getItem('isLoggedIn') === 'true';
+    const userStr = localStorage.getItem('user');
+    
+    setIsLoggedIn(loggedIn);
+    
+    if (!loggedIn) {
+      router.push('/login');
+      return;
+    }
+    
+    // ユーザー情報の取得
+    if (userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setCurrentUser(user);
+      } catch (error) {
+        console.error('ユーザー情報の解析エラー:', error);
+      }
+    }
+
+    fetchProject();
+    fetchTodo();
+  }, [router, projectId, todoId]);
+
+  // ログインしていない場合は何も表示しない（リダイレクト中）
+  if (!isLoggedIn) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>ログインページにリダイレクトしています...</p>
+    </div>;
+  }
+
+  if (isLoading) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>読み込み中...</p>
+    </div>;
+  }
+
+  if (!todo) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>Todoが見つかりません</p>
+    </div>;
+  }
+
+  const isAssignedToCurrentUser = currentUser && todo.assignedTo?.id === currentUser.id;
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* ブレッドクラム */}
+      <nav className="flex items-center space-x-2 text-sm text-gray-600 mb-6">
+        <button 
+          onClick={() => router.push('/')}
+          className="hover:text-gray-900"
+        >
+          プロジェクト
+        </button>
+        <span>→</span>
+        {project && <ProjectBadge project={project} />}
+        <span>→</span>
+        <button 
+          onClick={() => router.push(`/projects/${projectId}/todos`)}
+          className="hover:text-gray-900"
+        >
+          Todo一覧
+        </button>
+        <span>→</span>
+        <span className="text-gray-900">{todo.title}</span>
+      </nav>
+
+      {/* ヘッダー */}
+      <div className="flex justify-between items-center mb-8">
+        <div className="flex-1">
+          <div className="flex items-center space-x-4 mb-2">
+            {project && <ProjectBadge project={project} />}
+            {isAssignedToCurrentUser && (
+              <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                👤 担当中
+              </span>
+            )}
+            {todo.completed && (
+              <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                ✅ 完了
+              </span>
+            )}
+          </div>
+          <h1 className="text-3xl font-bold mb-2">{todo.title}</h1>
+          {todo.labels && todo.labels.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-4">
+              {todo.labels.map((labelRelation) => (
+                <LabelBadge key={labelRelation.label.id} label={labelRelation.label} />
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center space-x-4">
+          {currentUser && (
+            <div className="text-sm text-gray-600">
+              <span className="font-medium">ログイン中: </span>
+              <span className="text-gray-900">
+                {currentUser.name || currentUser.email}
+              </span>
+              {currentUser.name && (
+                <span className="text-gray-500 ml-1">({currentUser.email})</span>
+              )}
+            </div>
+          )}
+          <button
+            onClick={() => router.push('/profile')}
+            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            プロフィール設定
+          </button>
+          <button
+            onClick={handleLogout}
+            className="inline-flex justify-center rounded-md border border-transparent bg-gray-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+
+      {/* Todo詳細 */}
+      <div className="bg-white rounded-lg shadow-sm border p-6 mb-6">
+        {todo.description && (
+          <div className="mb-6">
+            <h2 className="text-lg font-semibold mb-2">説明</h2>
+            <p className="text-gray-700 whitespace-pre-wrap">{todo.description}</p>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">ステータス</h3>
+            <p className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
+              todo.completed 
+                ? 'bg-green-100 text-green-800' 
+                : 'bg-yellow-100 text-yellow-800'
+            }`}>
+              {todo.completed ? '✅ 完了' : '🔄 進行中'}
+            </p>
+          </div>
+
+          {todo.assignedTo && (
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-2">担当者</h3>
+              <p className={`text-sm ${isAssignedToCurrentUser ? 'font-medium text-blue-700' : 'text-gray-600'}`}>
+                {todo.assignedTo.name || todo.assignedTo.email}
+              </p>
+            </div>
+          )}
+
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">作成者</h3>
+            <p className="text-sm text-gray-600">
+              {todo.createdBy?.name || todo.createdBy?.email || '不明'}
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">作成日時</h3>
+            <p className="text-sm text-gray-600">
+              {new Date(todo.createdAt).toLocaleString('ja-JP')}
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-semibold text-gray-900 mb-2">更新日時</h3>
+            <p className="text-sm text-gray-600">
+              {new Date(todo.updatedAt).toLocaleString('ja-JP')}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* アクションボタン */}
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={toggleComplete}
+          className={`inline-flex justify-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            todo.completed
+              ? 'border-yellow-300 bg-yellow-50 text-yellow-700 hover:bg-yellow-100 focus:ring-yellow-500'
+              : 'border-green-300 bg-green-50 text-green-700 hover:bg-green-100 focus:ring-green-500'
+          }`}
+        >
+          {todo.completed ? '未完了にする' : '完了にする'}
+        </button>
+
+        <button
+          onClick={() => router.push(`/todos/${todo.id}/edit`)}
+          className="inline-flex justify-center rounded-md border border-indigo-300 bg-indigo-50 py-2 px-4 text-sm font-medium text-indigo-700 shadow-sm hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          編集
+        </button>
+
+        <button
+          onClick={deleteTodo}
+          className="inline-flex justify-center rounded-md border border-red-300 bg-red-50 py-2 px-4 text-sm font-medium text-red-700 shadow-sm hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+        >
+          削除
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/projects/[id]/todos/create/page.tsx
+++ b/app/projects/[id]/todos/create/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Project } from '@/app/types/todo';
+import ProjectBadge from '@/app/components/ProjectBadge';
+import TodoForm from '@/app/components/TodoForm';
+
+export default function CreateProjectTodo() {
+  const [project, setProject] = useState<Project | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.id as string;
+
+  const fetchProject = async () => {
+    try {
+      const response = await fetch(`/api/projects/${projectId}`);
+      if (!response.ok) {
+        throw new Error('プロジェクトの取得に失敗しました');
+      }
+      const data = await response.json();
+      setProject(data);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('プロジェクトの取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('user');
+    setIsLoggedIn(false);
+    setCurrentUser(null);
+    router.push('/login');
+  };
+
+  const handleTodoCreated = () => {
+    router.push(`/projects/${projectId}/todos`);
+  };
+
+  useEffect(() => {
+    // 認証状態チェック
+    const loggedIn = localStorage.getItem('isLoggedIn') === 'true';
+    const userStr = localStorage.getItem('user');
+    
+    setIsLoggedIn(loggedIn);
+    
+    if (!loggedIn) {
+      router.push('/login');
+      return;
+    }
+    
+    // ユーザー情報の取得
+    if (userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setCurrentUser(user);
+      } catch (error) {
+        console.error('ユーザー情報の解析エラー:', error);
+      }
+    }
+
+    fetchProject();
+  }, [router, projectId]);
+
+  // ログインしていない場合は何も表示しない（リダイレクト中）
+  if (!isLoggedIn) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>ログインページにリダイレクトしています...</p>
+    </div>;
+  }
+
+  if (isLoading) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>読み込み中...</p>
+    </div>;
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* ブレッドクラム */}
+      <nav className="flex items-center space-x-2 text-sm text-gray-600 mb-6">
+        <button 
+          onClick={() => router.push('/')}
+          className="hover:text-gray-900"
+        >
+          プロジェクト
+        </button>
+        <span>→</span>
+        {project && <ProjectBadge project={project} />}
+        <span>→</span>
+        <button 
+          onClick={() => router.push(`/projects/${projectId}/todos`)}
+          className="hover:text-gray-900"
+        >
+          Todo一覧
+        </button>
+        <span>→</span>
+        <span className="text-gray-900">新規作成</span>
+      </nav>
+
+      {/* ヘッダー */}
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <div className="flex items-center space-x-4 mb-2">
+            {project && <ProjectBadge project={project} />}
+          </div>
+          <h1 className="text-3xl font-bold">
+            {project ? `${project.name} - Todo作成` : 'Todo作成'}
+          </h1>
+          {project?.description && (
+            <p className="text-gray-600 mt-2">{project.description}</p>
+          )}
+        </div>
+        <div className="flex items-center space-x-4">
+          {currentUser && (
+            <div className="text-sm text-gray-600">
+              <span className="font-medium">ログイン中: </span>
+              <span className="text-gray-900">
+                {currentUser.name || currentUser.email}
+              </span>
+              {currentUser.name && (
+                <span className="text-gray-500 ml-1">({currentUser.email})</span>
+              )}
+            </div>
+          )}
+          <button
+            onClick={() => router.push('/profile')}
+            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            プロフィール設定
+          </button>
+          <button
+            onClick={handleLogout}
+            className="inline-flex justify-center rounded-md border border-transparent bg-gray-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+
+      {/* Todo作成フォーム */}
+      <div className="max-w-2xl">
+        <TodoForm 
+          projectId={parseInt(projectId)}
+          onTodoCreated={handleTodoCreated}
+          onCancel={() => router.push(`/projects/${projectId}/todos`)}
+        />
+      </div>
+    </main>
+  );
+}

--- a/app/projects/[id]/todos/page.tsx
+++ b/app/projects/[id]/todos/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import React from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { Todo, Project } from '@/app/types/todo';
+import LabelBadge from '@/app/components/LabelBadge';
+import ProjectBadge from '@/app/components/ProjectBadge';
+
+export default function ProjectTodos() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [project, setProject] = useState<Project | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUser, setCurrentUser] = useState<{id: number, email: string, name: string | null} | null>(null);
+  const router = useRouter();
+  const params = useParams();
+  const projectId = params.id as string;
+
+  const fetchProject = async () => {
+    try {
+      const response = await fetch(`/api/projects/${projectId}`);
+      if (!response.ok) {
+        throw new Error('プロジェクトの取得に失敗しました');
+      }
+      const data = await response.json();
+      setProject(data);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('プロジェクトの取得に失敗しました');
+    }
+  };
+
+  const fetchTodos = async () => {
+    try {
+      let url = `/api/todos?projectId=${projectId}`;
+      if (currentUser?.id) {
+        url += `&currentUserId=${currentUser.id}`;
+      }
+      
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error('Todoの取得に失敗しました');
+      }
+      const data = await response.json();
+      setTodos(data);
+    } catch (error) {
+      console.error('Error:', error);
+      alert('Todoの取得に失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('isLoggedIn');
+    localStorage.removeItem('user');
+    setIsLoggedIn(false);
+    setCurrentUser(null);
+    router.push('/login');
+  };
+
+  useEffect(() => {
+    // 認証状態チェック
+    const loggedIn = localStorage.getItem('isLoggedIn') === 'true';
+    const userStr = localStorage.getItem('user');
+    
+    setIsLoggedIn(loggedIn);
+    
+    if (!loggedIn) {
+      router.push('/login');
+      return;
+    }
+    
+    // ユーザー情報の取得
+    if (userStr) {
+      try {
+        const user = JSON.parse(userStr);
+        setCurrentUser(user);
+      } catch (error) {
+        console.error('ユーザー情報の解析エラー:', error);
+      }
+    }
+
+    fetchProject();
+  }, [router, projectId]);
+
+  // currentUserが設定された後にTodoを取得
+  useEffect(() => {
+    if (isLoggedIn && currentUser && project) {
+      fetchTodos();
+    }
+  }, [currentUser, isLoggedIn, project]);
+
+  // ログインしていない場合は何も表示しない（リダイレクト中）
+  if (!isLoggedIn) {
+    return <div className="min-h-screen flex items-center justify-center">
+      <p>ログインページにリダイレクトしています...</p>
+    </div>;
+  }
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* ブレッドクラム */}
+      <nav className="flex items-center space-x-2 text-sm text-gray-600 mb-6">
+        <button 
+          onClick={() => router.push('/')}
+          className="hover:text-gray-900"
+        >
+          プロジェクト
+        </button>
+        <span>→</span>
+        {project && <ProjectBadge project={project} />}
+        <span>→</span>
+        <span className="text-gray-900">Todo一覧</span>
+      </nav>
+
+      {/* ヘッダー */}
+      <div className="flex justify-between items-center mb-8">
+        <div>
+          <div className="flex items-center space-x-4 mb-2">
+            {project && <ProjectBadge project={project} />}
+          </div>
+          <h1 className="text-3xl font-bold">
+            {project ? `${project.name} - Todo一覧` : 'Todo一覧'}
+          </h1>
+          {project?.description && (
+            <p className="text-gray-600 mt-2">{project.description}</p>
+          )}
+        </div>
+        <div className="flex items-center space-x-4">
+          {currentUser && (
+            <div className="text-sm text-gray-600">
+              <span className="font-medium">ログイン中: </span>
+              <span className="text-gray-900">
+                {currentUser.name || currentUser.email}
+              </span>
+              {currentUser.name && (
+                <span className="text-gray-500 ml-1">({currentUser.email})</span>
+              )}
+            </div>
+          )}
+          <button
+            onClick={() => router.push('/profile')}
+            className="inline-flex justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            プロフィール設定
+          </button>
+          <button
+            onClick={handleLogout}
+            className="inline-flex justify-center rounded-md border border-transparent bg-gray-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+      
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-semibold">Todo一覧</h2>
+        <button
+          onClick={() => router.push(`/projects/${projectId}/todos/create`)}
+          className="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        >
+          新規作成
+        </button>
+      </div>
+      
+      <div>
+        {isLoading ? (
+          <p>読み込み中...</p>
+        ) : todos.length === 0 ? (
+          <div className="text-center py-8">
+            <p className="text-gray-500 mb-2">このプロジェクトにはまだTodoがありません</p>
+            <button
+              onClick={() => router.push(`/projects/${projectId}/todos/create`)}
+              className="text-indigo-600 hover:text-indigo-800"
+            >
+              最初のTodoを作成する
+            </button>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {todos.map((todo) => {
+              const isAssignedToCurrentUser = currentUser && todo.assignedTo?.id === currentUser.id;
+              return (
+                <li
+                  key={todo.id}
+                  className={`border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow ${
+                    isAssignedToCurrentUser 
+                      ? 'bg-blue-50 border-blue-200' 
+                      : 'bg-white'
+                  }`}
+                >
+                  <div className="cursor-pointer" onClick={() => router.push(`/projects/${projectId}/todos/${todo.id}`)}>
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          {isAssignedToCurrentUser && (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                              👤 担当中
+                            </span>
+                          )}
+                          {todo.completed && (
+                            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                              ✅ 完了
+                            </span>
+                          )}
+                          <h3 className="text-lg font-medium">{todo.title}</h3>
+                        </div>
+                        {todo.description && (
+                          <p className="text-gray-600 mt-1 mb-2">{todo.description}</p>
+                        )}
+                        {todo.labels && todo.labels.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mb-2">
+                            {todo.labels.map((labelRelation) => (
+                              <LabelBadge key={labelRelation.label.id} label={labelRelation.label} />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-500 text-right ml-4 flex-shrink-0">
+                        {todo.assignedTo && (
+                          <div className={`mb-1 ${isAssignedToCurrentUser ? 'font-medium text-blue-700' : ''}`}>
+                            担当: {todo.assignedTo.name || todo.assignedTo.email}
+                          </div>
+                        )}
+                        <div>作成: {todo.createdBy?.name || todo.createdBy?.email || '不明'}</div>
+                      </div>
+                    </div>
+                    <div className="flex justify-between items-center text-xs text-gray-400">
+                      <div className="flex gap-4">
+                        <span>作成: {new Date(todo.createdAt).toLocaleDateString()}</span>
+                        <span>更新: {new Date(todo.updatedAt).toLocaleDateString()}</span>
+                      </div>
+                      <div className="text-right">
+                        {new Date(todo.updatedAt).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,13 +28,13 @@ model Todo {
   userId      Int?
   createdById Int?
   assignedToId Int?
-  projectId   Int?
+  projectId   Int
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   user        User?    @relation(fields: [userId], references: [id])
   createdBy   User?    @relation("TodoCreatedBy", fields: [createdById], references: [id])
   assignedTo  User?    @relation("TodoAssignedTo", fields: [assignedToId], references: [id])
-  project     Project? @relation(fields: [projectId], references: [id])
+  project     Project  @relation(fields: [projectId], references: [id])
   labels      TodoLabel[]
 }
 
@@ -49,7 +49,7 @@ model Label {
 
 model Project {
   id          Int      @id @default(autoincrement())
-  name        String
+  name        String   @unique
   description String?
   color       String   @default("blue")
   createdById Int?


### PR DESCRIPTION
## Summary
- Redmine風のプロジェクト前提TODOアプリに変更しました
- データベーススキーマからUI・APIまで、プロジェクト管理を中心とした設計に全面的に刷新
- ユーザーは最初にプロジェクトを選択し、そのプロジェクト内でTodoを管理する新しいワークフローを実装

## 主な変更点

### 🗄️ データベーススキーマ変更
- **Todo.projectId を必須化**: `Int?` → `Int` （すべてのTodoは必ずプロジェクトに属する）
- **Project.name に一意性制約追加**: `@unique` （プロジェクト名の重複を防止）
- プロジェクト前提のデータ整合性を確保

### 🎯 画面構造の全面的な変更
- **ルートページ(`/`)**: プロジェクト選択画面に変更
  - 利用可能なプロジェクト一覧表示
  - 新規プロジェクト作成機能
  - プロジェクト編集・管理機能
- **プロジェクト固有Todo一覧**: `/projects/[id]/todos` 新設
- **プロジェクト固有Todo作成**: `/projects/[id]/todos/create` 新設  
- **プロジェクト固有Todo詳細**: `/projects/[id]/todos/[todoId]` 新設

### 🔗 API エンドポイント強化
- **Todo API にプロジェクトフィルタリング追加**: `?projectId=${id}` パラメータ対応
- **Todo作成時のprojectID必須化**: バリデーション強化
- **プロジェクトコンテキストでのTodo取得**: 指定プロジェクト内のTodoのみ取得

### 🎨 UI/UX改善
- **ブレッドクラムナビゲーション追加**: プロジェクト > Todo一覧 > Todo詳細の階層表示
- **プロジェクトバッジでの視覚的識別**: カラーコード化されたプロジェクト表示
- **TodoFormのプロジェクト固有対応**: 
  - プロジェクトが指定されている場合はプロジェクトセレクターを非表示
  - キャンセルボタン追加でUX向上

### 🔄 新しいワークフロー
1. **ログイン後**: プロジェクト選択画面（ルートページ）が表示
2. **プロジェクト選択**: クリックで該当プロジェクトのTodo一覧に移動
3. **Todo管理**: プロジェクト固有の環境でTodoを作成・編集・管理
4. **プロジェクト管理**: 設定ボタンからプロジェクトの編集・削除が可能
5. **階層ナビゲーション**: ブレッドクラムで現在位置を明確に表示

## Test plan
- [x] データベースマイグレーション実行済み
- [x] アプリケーション起動確認（http://localhost:3000）
- [x] 基本的な画面遷移動作確認
- [x] プロジェクト作成・選択・Todo管理の一連のフロー動作確認
- [ ] 既存テストの修正（プロジェクトID必須化に伴う調整が必要）

## 技術的詳細
- **Prisma**: スキーマ変更とマイグレーション適用
- **Next.js App Router**: 新しいルート構造で階層型ナビゲーション実装
- **TypeScript**: 型定義の整合性維持
- **Tailwind CSS**: 一貫したデザインシステム

🤖 Generated with [Claude Code](https://claude.ai/code)