### PR TITLE
fix: Docker Composeのnode_modulesボリューム競合エラーを修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,10 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/todo_app
     depends_on:
-      - db
+      db:
+        condition: service_started
+      migrate:
+        condition: service_completed_successfully
     command: sh scripts/migrate-dev.sh
 
   db:


### PR DESCRIPTION
## Summary
- migrate-devサービスにmigrateサービスへの依存関係を追加
- シンボリックリンク作成の競合を防止し、コンテナ起動エラーを解決

## 変更内容
- `docker-compose.yml`の`migrate-dev`サービスの`depends_on`に`migrate`サービスを追加
- 依存関係の設定により、migrateが完了してからmigrate-devが実行される

## 解決する問題
- 複数コンテナでの同時node_modulesアクセス競合
- .binディレクトリ内のシンボリックリンク重複作成エラー
- `docker compose up -d`時のコンテナ起動失敗

## テスト確認
- [x] Docker Composeでの起動テスト完了
- [x] シンボリックリンクエラーが発生しないことを確認
- [x] migrate → migrate-dev → app の順次実行を確認

closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)